### PR TITLE
Add more options for how sneaking should be handled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ classes/
 publish_all.sh
 publish_curseforge_version.sh
 publish_modrinth_version.sh
+
+# Essentially macOS's equivalent of desktop.ini
+.DS_Store

--- a/common/src/main/java/me/pieking1215/invmove/InvMoveConfig.java
+++ b/common/src/main/java/me/pieking1215/invmove/InvMoveConfig.java
@@ -52,9 +52,11 @@ public class InvMoveConfig {
         public final ConfigBool JUMP = cfg.bool("jump", true);
 
         public enum SneakMode {
-            Off, Maintain, Pressed
+            Off, Maintain, Pressed, MaintainWhilePressed
         }
         public final ConfigEnum<SneakMode> SNEAK = cfg.addEnum("sneak", SneakMode.Maintain).setMigrator(element -> GsonHelperFix.isBooleanValue(element) ? Optional.of(element.getAsBoolean() ? SneakMode.Pressed : SneakMode.Maintain) : Optional.empty());
+
+        public final ConfigEnum<SneakMode> SNEAK_DISALLOWED = cfg.addEnum("sneak_disallowed", SneakMode.Maintain);
 
         public final ConfigBool DISMOUNT = cfg.bool("dismount", false);
 

--- a/common/src/main/resources/assets/invmove/lang/en_us.json
+++ b/common/src/main/resources/assets/invmove/lang/en_us.json
@@ -13,6 +13,8 @@
   "tooltip.config.invmove.movement.enable": "Enable movement while inside inventories.\nYou can manually turn off certain inventories below.\nThere is a keybind you can set to toggle this.",
   "config.invmove.movement.sneak": "Sneak Mode",
   "tooltip.config.invmove.movement.sneak": "How to handle sneaking while inside inventories:\nOff = No sneaking\nMaintain = Keep sneaking if you were when the inventory opened\nPressed = Sneak only while holding the sneak button\n(Pressed can be distracting when shift-clicking)\n(If using toggle sneak, Pressed allows toggling and both other modes maintain)",
+  "config.invmove.movement.sneak_disallowed": "Sneak Mode When Disallowed",
+  "tooltip.config.invmove.movement.sneak_disallowed": "Determines sneaking behavior inside inventories that have movement disabled.\nOff = Automatically unsneak (Vanilla behavior)\nMaintain = Keep sneaking if you were when you opened the inventory\nPressed = Sneak only while holding the sneak button\n(Pressed can be distracting when shift-clicking)\n(If using toggle sneak, Pressed allows toggling and both other modes maintain)",
   "config.invmove.movement.jump": "Allow Jumping",
   "tooltip.config.invmove.movement.jump": "Allow jumping while inside inventories.",
   "config.invmove.movement.dismount": "Allow Dismounting",


### PR DESCRIPTION
Fixes #85

This pull request introduces a `MaintainWhilePressed` SneakMode, and an option to configure how sneaking should be handled in disallowed inventories. (`Maintain` by default to match old behavior)

`MaintainWhilePressed` is like `Maintain`, except sneaking ends when the button is released, while not re-sneaking when pressing again.

The `sneak_disallowed` option decides the SneakMode to use in disabled inventories, to optionally allow for, for example, matching vanilla behavior with `Off` for disabled inventories.

(I also added `.DS_Store` to the gitignore which is a metadata file generated by macOS akin to `desktop.ini`. These are somewhat painful to remove manually, which is why I added this entry.)